### PR TITLE
Clarify deprecation of redir in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Redir
 
-Redirects neovim's [cmdline](https://neovim.io/doc/user/cmdline.html) output to a modifiable buffer.
+Archived: deprecated in favor of Neovim's native `vim._core.ui2` message and cmdline presentation layer. Redirects neovim's [cmdline](https://neovim.io/doc/user/cmdline.html) output to a modifiable buffer.
 
 ## Motivation
 

--- a/doc/redir.nvim.txt
+++ b/doc/redir.nvim.txt
@@ -1,4 +1,5 @@
-*redir.nvim.txt*           For NVIM v0.10.3           Last change: 2025 May 12
+*redir.nvim.txt*
+                                 For NVIM v0.10.3    Last change: 2026 July 03
 
 ==============================================================================
 Table of Contents                               *redir.nvim-table-of-contents*
@@ -15,7 +16,9 @@ Table of Contents                               *redir.nvim-table-of-contents*
 ==============================================================================
 1. Redir                                                    *redir.nvim-redir*
 
-Redirects neovim’s |cmdline| output to a modifiable buffer.
+Archived: deprecated in favor of Neovim’s native `vim._core.ui2` message and
+cmdline presentation layer. Redirects neovim’s |cmdline| output to a
+modifiable buffer.
 
 
 MOTIVATION                                       *redir.nvim-redir-motivation*


### PR DESCRIPTION
Updated README to indicate deprecation in favor of Neovim's native cmdline presentation layer.